### PR TITLE
Paste for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Clipboard Utilities
 -------------------
 
  - OSX     - `pbcopy` and `pbpaste`
- - Windows - `clip` and `paste`
+ - Windows - `clip` and `powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"`
  - Linux   - `xsel`
 
  **Note:** `xsel` can be installed with `apt-get install xsel` if your system doesn't have it installed


### PR DESCRIPTION
'paste' doesn't work in windows, the below settings work in windows.

let g:system_copy#copy_command='clip'
let g:system_copy#paste_command='powershell.exe -NoLogo -NoProfile -Noninteractive -Command "Get-Clipboard"'